### PR TITLE
Headered reading

### DIFF
--- a/configurations/example.yaml
+++ b/configurations/example.yaml
@@ -5,21 +5,21 @@ case_quantity: 500 # Generate 500 cases
 
 demands: # Read demands points in Tijuana from file
   class: ems.datasets.location.demand.demand_set.DemandSet
-  filename: "../data-cruz-roja/demand_points.csv"
+  filename: "../data-cruz-roja-clean/demand_points.csv"
 
 all_bases: # Read base points in Tijuana from file
   class: ems.datasets.location.base.base_set.BaseSet
-  filename: "../data-cruz-roja/bases.csv"
+  filename: "../data-cruz-roja-clean/bases.csv"
 
 tt: # Travel times matrix between all bases and all demands
   class: ems.datasets.travel_times.travel_times.TravelTimes
-  filename: "../data-cruz-roja/times.csv"
+  filename: "../data-cruz-roja-clean/times.csv"
   origins: "@all_bases"
   destinations: "@demands"
 
 simulation_bases: # Selects a subset of bases for usage in the simulation (K-Means filtered)
   class: ems.datasets.location.base.filtered_base_set.FilteredBaseSet
-  filename: "../data-cruz-roja/bases.csv"
+  filename: "../data-cruz-roja-clean/bases.csv"
   count: 16
   required_travel_time: 600
   travel_times: "@tt"

--- a/ems/datasets/location/base/base_set.py
+++ b/ems/datasets/location/base/base_set.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from ems.datasets.location.kd_tree_location_set import KDTreeLocationSet
-from ems.utils import parse_unheadered_csv
+from ems.utils import parse_headered_csv
 
 
 class BaseSet(KDTreeLocationSet):
@@ -16,16 +16,15 @@ class BaseSet(KDTreeLocationSet):
         super().__init__(latitudes, longitudes)
 
     def read_bases(self, filename):
-        # Read bases from an unheadered CSV into a pandas dataframe
-        base_col_positions = [4, 5]
-        base_headers = ["lat", "long"]
-        bases_df = parse_unheadered_csv(filename, base_col_positions, base_headers)
+        # Read bases from a headered CSV into a pandas dataframe
+        base_headers = ["latitude", "longitude"]
+        bases_df = parse_headered_csv(filename, base_headers)
 
         # Generate list of models from dataframe
         latitudes = []
         longitudes = []
         for index, row in bases_df.iterrows():
-            latitudes.append(row["lat"])
-            longitudes.append(row["long"])
+            latitudes.append(row["latitude"])
+            longitudes.append(row["longitude"])
 
         return latitudes, longitudes

--- a/ems/datasets/location/base/filtered_base_set.py
+++ b/ems/datasets/location/base/filtered_base_set.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from ems.datasets.location.kd_tree_location_set import KDTreeLocationSet
 from ems.datasets.travel_times.travel_times import TravelTimes
-from ems.utils import parse_unheadered_csv
+from ems.utils import parse_headered_csv
 
 
 class FilteredBaseSet(KDTreeLocationSet):
@@ -28,17 +28,16 @@ class FilteredBaseSet(KDTreeLocationSet):
         super().__init__(latitudes, longitudes)
 
     def read_bases(self, filename):
-        # Read bases from an unheadered CSV into a pandas dataframe
-        base_col_positions = [4, 5]
-        base_headers = ["lat", "long"]
-        bases_df = parse_unheadered_csv(filename, base_col_positions, base_headers)
+        # Read bases from a headered CSV into a pandas dataframe
+        base_headers = ["latitude", "longitude"]
+        bases_df = parse_headered_csv(filename, base_headers)
 
         # Generate list of models from dataframe
         latitudes = []
         longitudes = []
         for index, row in bases_df.iterrows():
-            latitudes.append(row["lat"])
-            longitudes.append(row["long"])
+            latitudes.append(row["latitude"])
+            longitudes.append(row["longitude"])
 
         return latitudes, longitudes
 

--- a/ems/datasets/location/demand/demand_set.py
+++ b/ems/datasets/location/demand/demand_set.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from ems.datasets.location.kd_tree_location_set import KDTreeLocationSet
-from ems.utils import parse_unheadered_csv
+from ems.utils import parse_headered_csv
 
 
 class DemandSet(KDTreeLocationSet):
@@ -15,16 +15,15 @@ class DemandSet(KDTreeLocationSet):
         super().__init__(latitudes, longitudes)
 
     def read_demands(self, filename):
-        # Read demands from an unheadered CSV into a pandas dataframe
-        demand_col_positions = [0, 1]
-        demand_headers = ["lat", "long"]
-        demands_df = parse_unheadered_csv(filename, demand_col_positions, demand_headers)
+        # Read demands from a headered CSV into a pandas dataframe
+        demand_headers = ["latitude", "longitude"]
+        demands_df = parse_headered_csv(filename, demand_headers)
 
         # Generate list of models from dataframe
         latitudes = []
         longitudes = []
         for index, row in demands_df.iterrows():
-            latitudes.append(row["lat"])
-            longitudes.append(row["long"])
+            latitudes.append(row["latitude"])
+            longitudes.append(row["longitude"])
 
         return latitudes, longitudes

--- a/ems/datasets/location/hospital/hospital_set.py
+++ b/ems/datasets/location/hospital/hospital_set.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from ems.datasets.location.kd_tree_location_set import KDTreeLocationSet
-from ems.utils import parse_unheadered_csv
+from ems.utils import parse_headered_csv
 
 
 class HospitalSet(KDTreeLocationSet):
@@ -15,16 +15,15 @@ class HospitalSet(KDTreeLocationSet):
         super().__init__(latitudes, longitudes)
 
     def read_hospitals(self, filename):
-        # Read hospitals from an unheadered CSV into a pandas dataframe
-        hospital_col_positions = [0, 1]
-        hospital_headers = ["lat", "long"]
-        hospitals_df = parse_unheadered_csv(filename, hospital_col_positions, hospital_headers)
+        # Read hospitals from a headered CSV into a pandas dataframe
+        hospital_headers = ["latitude", "longitude"]
+        hospitals_df = parse_headered_csv(filename, hospital_headers)
 
         # Generate list of models from dataframe
         latitudes = []
         longitudes = []
         for index, row in hospitals_df.iterrows():
-            latitudes.append(row["lat"])
-            longitudes.append(row["long"])
+            latitudes.append(row["latitude"])
+            longitudes.append(row["longitude"])
 
         return latitudes, longitudes


### PR DESCRIPTION
Changes base sets, demand sets, and hospital sets to be read in from headered CSV files instead of unheadered CSV files. The headers are: 'latitude' and 'longitude'. This enforces that all CSV files fed into the simulation MUST be headered.

I've also attached a zip of the cleaned cruz roja data which only contains the essential files for the simulation. In addition, the base CSV now does not contain all the previously useless columns.

[data-cruz-roja-clean.zip](https://github.com/EMSTrack/Algorithms/files/2849576/data-cruz-roja-clean.zip)
